### PR TITLE
chore: update publish workflow and add workflow for minor/major releases

### DIFF
--- a/.github/workflows/publish-ci.yml
+++ b/.github/workflows/publish-ci.yml
@@ -1,7 +1,10 @@
 name: Publish ModelHub Packages
 
 on:
-  workflow_dispatch:
+  workflow_run:
+    workflows: ['CI']
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -12,6 +15,7 @@ jobs:
   verify-and-publish:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
 
     steps:
       - name: Checkout Repository
@@ -42,13 +46,6 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=4096
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build example applications
-        run: |
-          yarn browser build
-          yarn electron build
-        env:
-          NODE_OPTIONS: --max_old_space_size=4096
-
       - name: Lint with ESLint
         run: yarn lint
 
@@ -59,8 +56,8 @@ jobs:
         # Scripts are ignored because we build and lint before this step
       - name: Publish packages
         run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git config user.email 'eclipse-emfcloud-bot@eclipse.org'
+          git config user.name 'eclipse-emfcloud-bot'
           yarn lerna publish -y --ignore-scripts --loglevel=verbose
         env:
           NPM_CONFIG_PROVENANCE: 'true'

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -1,0 +1,73 @@
+name: Release ModelHub Packages
+
+on:
+  workflow_dispatch:
+    inputs:
+      version-type:
+        description: 'Version type to release (minor or major)'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - minor
+          - major
+
+permissions:
+  contents: write
+  packages: write
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4.2.0
+        with:
+          fetch-depth: 0 # pulls all history and tags for Lerna to detect which packages changed
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4.0.4
+        with:
+          node-version: 20.x
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install tools and libraries
+        run: sudo apt-get install -y build-essential libx11-dev libxkbfile-dev libsecret-1-dev
+
+      - name: Use Python 3.11
+        uses: actions/setup-python@v5.2.0
+        with:
+          python-version: '3.11'
+
+      - name: Install and Build
+        shell: bash
+        run: |
+          yarn global add node-gyp
+          yarn --skip-integrity-check --network-timeout 100000
+        env:
+          NODE_OPTIONS: --max_old_space_size=4096
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Lint with ESLint
+        run: yarn lint
+
+      - name: Run tests
+        run: yarn test
+
+      - name: Determine Version Type
+        id: version_type
+        run: echo "VERSION_TYPE=${{ github.event.inputs['version-type'] }}" >> $GITHUB_ENV
+
+      - name: Publish packages
+        run: |
+          git config user.email 'eclipse-emfcloud-bot@eclipse.org'
+          git config user.name 'eclipse-emfcloud-bot'
+          # Using the chosen version type (minor or major) for Lerna publish
+          yarn lerna version $VERSION_TYPE -y --ignore-scripts --loglevel=verbose --message "chore(release): publish ModelHub $VERSION_TYPE version"
+          yarn lerna publish from-package -y --ignore-scripts --loglevel=verbose
+        env:
+          NPM_CONFIG_PROVENANCE: 'true'
+          NODE_AUTH_TOKEN: ${{ secrets.NPMJS_TOKEN }}

--- a/ext/model-service-theia/README.md
+++ b/ext/model-service-theia/README.md
@@ -1,6 +1,6 @@
-# Eclipse EMF Cloud Model Manager
+# Eclipse EMF Cloud Model Service for Eclipse Theia Applications
 
-The _Model Manager_ is an API for command-based editing, with undo/redo, of "models" primarily targeting JSON documents.
+Model Service for Eclipse Theia is a versatile solution designed to enhance Eclipse Theia applications by providing model management and interaction capabilities.
 
 For more information, please visit the [EMF Cloud Website](https://www.eclipse.org/emfcloud/).
 If you have questions, contact us on our [discussions page](https://github.com/eclipse-emfcloud/emfcloud/discussions)

--- a/ext/model-service-theia/package.json
+++ b/ext/model-service-theia/package.json
@@ -2,6 +2,12 @@
   "name": "@eclipse-emfcloud/model-service-theia",
   "version": "1.2.1",
   "description": "Model service Theia",
+  "keywords": [
+    "theia-extension",
+    "eclipse",
+    "emfcloud",
+    "model-management"
+  ],
   "license": "(EPL-2.0 OR MIT)",
   "contributors": [
     {

--- a/npm/model-accessor-bus/README.md
+++ b/npm/model-accessor-bus/README.md
@@ -1,3 +1,19 @@
-# Model Accessor Bus
+# Eclipse EMF Cloud Model Accessor Bus
 
 The _Model Accessor Bus_ is an API allowing the retrieval of data coming from "models" primarily targeting JSON documents.
+
+For more information, please visit the [EMF Cloud Website](https://www.eclipse.org/emfcloud/).
+If you have questions, contact us on our [discussions page](https://github.com/eclipse-emfcloud/emfcloud/discussions)
+and have a look at our [communication and support options](https://www.eclipse.org/emfcloud/contact/).
+
+## License
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License v. 2.0 which is available at
+<http://www.eclipse.org/legal/epl-2.0>.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License v. 2.0 are satisfied: MIT.
+
+SPDX-License-Identifier: EPL-2.0 OR MIT

--- a/npm/model-accessor-bus/package.json
+++ b/npm/model-accessor-bus/package.json
@@ -2,6 +2,12 @@
   "name": "@eclipse-emfcloud/model-accessor-bus",
   "version": "1.0.1",
   "description": "Model data access interface.",
+  "keywords": [
+    "theia-extension",
+    "eclipse",
+    "emfcloud",
+    "model-management"
+  ],
   "license": "(EPL-2.0 OR MIT)",
   "contributors": [
     {

--- a/npm/model-manager/package.json
+++ b/npm/model-manager/package.json
@@ -2,6 +2,12 @@
   "name": "@eclipse-emfcloud/model-manager",
   "version": "1.0.1",
   "description": "Command-based model editing with undo/redo.",
+  "keywords": [
+    "theia-extension",
+    "eclipse",
+    "emfcloud",
+    "model-management"
+  ],
   "license": "(EPL-2.0 OR MIT)",
   "contributors": [
     {

--- a/npm/model-service/README.md
+++ b/npm/model-service/README.md
@@ -1,6 +1,6 @@
-# Eclipse EMF Cloud Model Manager
+# Eclipse EMF Cloud Model Service
 
-The _Model Manager_ is an API for command-based editing, with undo/redo, of "models" primarily targeting JSON documents.
+Model Service provides a framework for model management.
 
 For more information, please visit the [EMF Cloud Website](https://www.eclipse.org/emfcloud/).
 If you have questions, contact us on our [discussions page](https://github.com/eclipse-emfcloud/emfcloud/discussions)

--- a/npm/model-service/package.json
+++ b/npm/model-service/package.json
@@ -2,6 +2,12 @@
   "name": "@eclipse-emfcloud/model-service",
   "version": "1.0.1",
   "description": "Model service framework",
+  "keywords": [
+    "theia-extension",
+    "eclipse",
+    "emfcloud",
+    "model-management"
+  ],
   "license": "(EPL-2.0 OR MIT)",
   "contributors": [
     {

--- a/npm/model-validation/README.md
+++ b/npm/model-validation/README.md
@@ -1,3 +1,19 @@
-# Model Validation
+# Eclipse EMF Cloud Model Validation
 
 The _Model Validation_ package is an API for validation of models, where "models" primarily are JSON documents.
+
+For more information, please visit the [EMF Cloud Website](https://www.eclipse.org/emfcloud/).
+If you have questions, contact us on our [discussions page](https://github.com/eclipse-emfcloud/emfcloud/discussions)
+and have a look at our [communication and support options](https://www.eclipse.org/emfcloud/contact/).
+
+## License
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License v. 2.0 which is available at
+<http://www.eclipse.org/legal/epl-2.0>.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License v. 2.0 are satisfied: MIT.
+
+SPDX-License-Identifier: EPL-2.0 OR MIT

--- a/npm/model-validation/package.json
+++ b/npm/model-validation/package.json
@@ -2,6 +2,13 @@
   "name": "@eclipse-emfcloud/model-validation",
   "version": "1.0.1",
   "description": "Generic model validation framework.",
+  "keywords": [
+    "theia-extension",
+    "eclipse",
+    "emfcloud",
+    "model-management",
+    "validation"
+  ],
   "license": "(EPL-2.0 OR MIT)",
   "contributors": [
     {

--- a/npm/trigger-engine/README.md
+++ b/npm/trigger-engine/README.md
@@ -1,3 +1,19 @@
-# Trigger Engine
+# Eclipse EMF Cloud Trigger Engine
 
 The _Trigger Engine_ package is an API for computing follow-up changes to be applied to JSON documents after application of patches, to proactively ensure data integrity.
+
+For more information, please visit the [EMF Cloud Website](https://www.eclipse.org/emfcloud/).
+If you have questions, contact us on our [discussions page](https://github.com/eclipse-emfcloud/emfcloud/discussions)
+and have a look at our [communication and support options](https://www.eclipse.org/emfcloud/contact/).
+
+## License
+
+This program and the accompanying materials are made available under the
+terms of the Eclipse Public License v. 2.0 which is available at
+<http://www.eclipse.org/legal/epl-2.0>.
+
+This Source Code may also be made available under the following Secondary
+Licenses when the conditions for such availability set forth in the Eclipse
+Public License v. 2.0 are satisfied: MIT.
+
+SPDX-License-Identifier: EPL-2.0 OR MIT

--- a/npm/trigger-engine/package.json
+++ b/npm/trigger-engine/package.json
@@ -2,6 +2,12 @@
   "name": "@eclipse-emfcloud/trigger-engine",
   "version": "1.0.1",
   "description": "Generic model triggers computation engine.",
+  "keywords": [
+    "theia-extension",
+    "eclipse",
+    "emfcloud",
+    "model-management"
+  ],
   "license": "(EPL-2.0 OR MIT)",
   "contributors": [
     {


### PR DESCRIPTION
- chore: update publish workflow and published package READMEs 
  - Update publish CI workflow
    - Update trigger and only execute if CI workflow was successful
    - Use eclipse-emfcloud-bot to publish packages
  - Add READMEs and keywords for published packages
- chore: add manual workflow for minor/major releases

Resolves GH-4