### PR TITLE
Add latest features

### DIFF
--- a/docs/guides/model-management-user-guide.md
+++ b/docs/guides/model-management-user-guide.md
@@ -17,6 +17,7 @@ This document provides scenario-oriented guidance for adopters of the Model Mana
         -   [Advanced Command Scenarios](#advanced-command-scenarios)
             -   [Executing a Command on Multiple Stacks](#executing-a-command-on-multiple-stacks)
             -   [Command Stack Subscriptions](#command-stack-subscriptions)
+      * [Deferred Composition of Commands](#deferred-composition-of-commands)
 -   [Model Validation Service](#model-validation-service)
     -   [Model Validation Subscriptions](#model-validation-subscriptions)
 -   [Trigger Engine](#trigger-engine)
@@ -357,6 +358,7 @@ import {
     CommandStack,
     append,
     createModelUpdaterCommandWithResult,
+    unwrapReturnResult
 } from '@eclipse-emfcloud/model-manager';
 
 const alice: AddressEntry = {
@@ -399,15 +401,18 @@ await stack.execute(addAlice);
 And then let us see what the result of this command is:
 
 ```typescript
-console.log('Inserted entry at index', addAlice.result!.index);
+const result = unwrapReturnResult(addAlice);
+console.log('Inserted entry at index', result!.index);
 
 // Inserted entry at index 0
 ```
 
 Well, yes of course, because the address book was initially empty, the index at which this entry was inserted could only be zero.
 
-Until the command is executed, its `result` property will be `undefined`.
-After successful execution, it will have whatever value was returned by the model updater function.
+Until the command is executed, its `result` property will be a `PendingResult` and unwrapping it yields `undefined`.
+After successful execution, it will be a `ReadyResult` that contains whatever value was returned by the model updater function.
+In the event that the execution fails with an error, the command's return result will be a `FailedResult` that contains the error
+and unwrapping the command's return result rethrows that error.
 
 These commands can be composed into larger units just like any others:
 
@@ -424,8 +429,8 @@ const addCathy = addAddressEntry({
 });
 await stack.execute(append(addBobbi, addCathy));
 
-console.log('Bobbi inserted at index', addBobbi.result!.index);
-console.log('Cathy inserted at index', addCathy.result!.index);
+console.log('Bobbi inserted at index', unwrapReturnResult(addBobbi)!.index);
+console.log('Cathy inserted at index', unwrapReturnResult(addCathy)!.index);
 
 // Bobby inserted at index 0
 // Cathy inserted at index 1
@@ -437,9 +442,9 @@ As a special case, commands may be composed in a chain where the results of earl
 
 [back to top ↩︎](#contents)
 
-As JSON patch is only defined for JSON documents, it lacks specification pertaining to `undefined` values.
+As JSON patch is only defined for JSON documents; it lacks specification pertaining to `undefined` values.
 While [fast-json-patch has some capabilities to work around `undefined` values][fast-json-patch-undefined], sadly they are not sufficient out of the box.
-Its modification operations are handled according to the workaround, however the generated "test" operations will fail as they can't test for `undefined` values.
+Its modification operations are handled according to the work-around, however the generated "test" operations will fail as they can't test for `undefined` values.
 As a consequence, working with fast-json-patch directly might lead to non-applicable patches in case such `undefined` values are part of the used models.
 
 To avoid these problems, the user might only want to operate on and modify their models in a JSON compatible way.
@@ -672,7 +677,7 @@ In review, this code sample illustrates several noteworthy points:
 
 [back to top ↩︎](#contents)
 
-In addition to make dependent changes in other models when we execute commands to change our own, oftentimes the inverse is true: we need to makes changes to _our_ models when we detect changes in some other related models.
+In addition to making dependent changes in other models when we execute commands to change our own, often the inverse is true: we need to makes changes to _our_ models when we detect changes in some other related models.
 
 #### Model Manager Subscriptions
 
@@ -1602,6 +1607,73 @@ Undo dependencies work exactly the same as redo dependencies, where in order to 
 
 By default, undo and redo try implicitly to include dependencies for convenience.
 In applications in which this can result in surprising side-effects, the analysis operations of the `CoreCommandStack` API provide the dependency information that can be presented to users in the UI to obtain informed consent to include dependencies, or to indicate specifically why undo or redo are not available even accounting for dependencies.
+
+#### Deferred Composition of Commands
+
+<details>
+<summary>Source Code</summary>
+
+The example code in this section may be found in the repository in the [`@example/model-management` package's `model-commands-advanced.ts` script](../../examples/guide/model-management/src/model-commands-advanced.ts) and may be run by executing `yarn example:advancedcommands` in a terminal.
+</details>
+
+Occasionally it can be difficult, or expensive, to determine _a priori_ all of the edits required to perform some logical change to the user's data and construct a complex command that may never be executed.
+This is especially common when dealing with commands that span multiple models with complex interdependencies.
+For these cases, the framework provides _Deferred Compound Commands_ that defer all the work of creating their nested commands until it is actually time to execute them.
+
+A relatively straight-forward case is the execution of commands that may or may not have dependencies met in the model, where in the case that they are not met, we also want to include commands to satisfy those dependencies.
+For example, when adding a `Shipment` to our example package-tracking model, we want to ensure that the recipient exists in the `AddressBook` model and also that that recipient has in its list of addresses the address to which we are sending the package.
+
+To accomplish this, we can create a deferred compound command and tell it, via a list of model IDs declared up-front, that it will be editing the package-tracking model and the address-book model.
+It doesn't matter whether some of these declared models don't end up needing to be modified by any commands that we will add to the composite; the benefit is that our command provider and consequently the compound command will have exclusive access to these models with the guarantee that they will not change concurrently, in case we do need to edit them.
+
+```typescript
+import { AddressBook, AddressEntry, getAddressBookEntryWithPointer, hasAddressMatching } from './address-book';
+import { Shipment } from './package-tracking';
+import { createDeferredCompoundCommand } from '@eclipse-emfcloud/model-manager';
+
+const addShipmentWithDependenciesCommand = createDeferredCompoundCommand(
+  'Add all the Things',
+  ['example:contacts.addressbook', 'example:packages.shipping'],
+  function* (getModel) {
+    const addressBook = getModel<AddressBook>('example:contacts.addressbook');
+    if (!addressBook) {
+      throw new Error('No address book found.');
+    }
+
+    // Do we need to add an entry? If so, yield it and it will be added to the compound.
+    const existingEntry = getAddressBookEntryWithPointer(addressBook, 'Brown', 'Alice');
+    if (!existingEntry) {
+      const entryToAdd: AddressEntry = { lastName: 'Brown', firstName: 'Alice', addresses: [] };
+      yield createAddEntryCommand(entryToAdd);
+    }
+
+    const shipmentToAdd: Shipment = {
+      recipient: { lastName: 'Brown', firstName: 'Alice' },
+      shipTo: {
+        numberAndStreet: '123 Front Street',
+        city: 'Exampleville',
+        province: 'Ontario',
+        country: 'Canada',
+      },
+    };
+
+    // We're adding a shipment. Do we also need to add the address?
+    // Note that if there wasn't an existing entry, we'd have to add
+    // the address because we created the new entry without any address
+    if (!existingEntry || !hasAddressMatching(existingEntry[0], shipmentToAdd.shipTo)
+    ) {
+      yield createAddAddressCommand(shipmentToAdd.recipient.lastName, shipmentToAdd.recipient.firstName,
+        { kind: 'home', ...shipmentToAdd.shipTo });
+    }
+
+    // And, finally, the command to add the actual shipment
+    yield createAddShipmentCommand(shipmentToAdd);
+  }
+);
+```
+
+Note how the example above uses a JavaScript generator function to provide the commands to include in the composite, using a convenient sequential programming model with conditions to yield commands one by one as they are determined to be necessary and are constructed.
+The deferred compound command also supports asynchronous provision of the commands and individual commands being returned as promises, for example from other APIs that asynchronously create them.
 
 #### Command Stack Subscriptions
 

--- a/examples/guide/model-management/src/address-book.ts
+++ b/examples/guide/model-management/src/address-book.ts
@@ -64,3 +64,19 @@ export function getAddressBookEntryWithPointer(
   }
   return undefined;
 }
+
+export function hasAddressMatching(
+  entry: AddressEntry,
+  pattern: Partial<Address>
+): boolean {
+  const matches = (address: Address): boolean => {
+    for (const [key, value] of Object.entries(pattern)) {
+      if (address[key as keyof Address] !== value) {
+        return false;
+      }
+    }
+    return true;
+  };
+
+  return entry.addresses.some(matches);
+}

--- a/examples/guide/model-management/src/model-commands-advanced.ts
+++ b/examples/guide/model-management/src/model-commands-advanced.ts
@@ -17,6 +17,7 @@ import {
   Command,
   ModelManager,
   append,
+  createDeferredCompoundCommand,
   createModelManager,
   createModelUpdaterCommand,
 } from '@eclipse-emfcloud/model-manager';
@@ -25,6 +26,7 @@ import {
   AddressBook,
   AddressEntry,
   getAddressBookEntryWithPointer,
+  hasAddressMatching,
 } from './address-book';
 import { PackageTracking, Shipment } from './package-tracking';
 
@@ -492,15 +494,141 @@ async function commandStackSubscription(modelManager: ModelManager<string>) {
   dispose();
 }
 
+async function addShipmentWithNewDeliveryAddressDeferred(
+  modelManager: ModelManager<string>
+) {
+  const addShipmentWithDependenciesCommand = createDeferredCompoundCommand(
+    'Add all the Things',
+    ['example:contacts.addressbook', 'example:packages.shipping'],
+    function* (getModel) {
+      const addressBook = getModel<AddressBook>('example:contacts.addressbook');
+      if (!addressBook) {
+        throw new Error('No address book found.');
+      }
+
+      // Do we need to add an entry? If so, yield it and it will be added to the compound.
+      const existingEntry = getAddressBookEntryWithPointer(
+        addressBook,
+        'Brown',
+        'Alice'
+      );
+      if (!existingEntry) {
+        const entryToAdd: AddressEntry = {
+          lastName: 'Brown',
+          firstName: 'Alice',
+          addresses: [],
+        };
+        yield createAddEntryCommand(entryToAdd);
+      }
+
+      const shipmentToAdd: Shipment = {
+        recipient: {
+          lastName: 'Brown',
+          firstName: 'Alice',
+        },
+        shipTo: {
+          numberAndStreet: '123 Front Street',
+          city: 'Exampleville',
+          province: 'Ontario',
+          country: 'Canada',
+        },
+      };
+
+      // We're adding a shipment. Do we also need to add the address?
+      // Note that if there wasn't an existing entry, we'd have to add
+      // the address because we created the new entry without any address
+      if (
+        !existingEntry ||
+        !hasAddressMatching(existingEntry[0], shipmentToAdd.shipTo)
+      ) {
+        yield createAddAddressCommand(
+          shipmentToAdd.recipient.lastName,
+          shipmentToAdd.recipient.firstName,
+          { kind: 'home', ...shipmentToAdd.shipTo }
+        );
+      }
+
+      // And, finally, the command to add the actual shipment
+      yield createAddShipmentCommand(shipmentToAdd);
+    }
+  );
+
+  const addressBookStack = modelManager.getCommandStack('address-book');
+  await addressBookStack.execute(addShipmentWithDependenciesCommand);
+
+  let addressBook = modelManager.getModel<AddressBook>(
+    'example:contacts.addressbook'
+  );
+  let packageTracking = modelManager.getModel<PackageTracking>(
+    'example:packages.shipping'
+  );
+
+  console.log('Contacts address book:', inspect(addressBook));
+  console.log('Package tracking:', inspect(packageTracking));
+
+  // Contacts address book: {
+  //   entries: [
+  //     {
+  //       lastName: 'Brown',
+  //       firstName: 'Alice',
+  //       addresses: [
+  //         {
+  //           kind: 'home',
+  //           numberAndStreet: '123 Front Street',
+  //           city: 'Exampleville',
+  //           province: 'Ontario',
+  //           country: 'Canada'
+  //         }
+  //       ]
+  //     }
+  //   ]
+  // }
+  // Package tracking: {
+  //   shipments: [
+  //     {
+  //       recipient: { lastName: 'Brown', firstName: 'Alice' },
+  //       shipTo: {
+  //         numberAndStreet: '123 Front Street',
+  //         city: 'Exampleville',
+  //         province: 'Ontario',
+  //         country: 'Canada'
+  //       }
+  //     }
+  //   ]
+  // }
+
+  await addressBookStack.undo();
+
+  addressBook = modelManager.getModel<AddressBook>(
+    'example:contacts.addressbook'
+  );
+  packageTracking = modelManager.getModel<PackageTracking>(
+    'example:packages.shipping'
+  );
+
+  console.log('Contacts address book:', inspect(addressBook));
+  console.log('Package tracking:', inspect(packageTracking));
+
+  // Contacts address book: { entries: [] }
+  // Package tracking: { shipments: [] }
+}
+
 async function main() {
+  console.log('--- Broken scenario ---');
   let modelManager = createModels();
   await addShipmentWithNewDeliveryAddressBroken(modelManager);
 
+  console.log('--- Fixed scenario ---');
   modelManager = createModels();
   await addShipmentWithNewDeliveryAddressFixed(modelManager);
 
+  console.log('--- Command-stack subscription ---');
   modelManager = createModels();
   await commandStackSubscription(modelManager);
+
+  console.log('--- Deferred compound command ---');
+  modelManager = createModels();
+  await addShipmentWithNewDeliveryAddressDeferred(modelManager);
 }
 
 main();

--- a/examples/guide/model-management/src/model-manager.ts
+++ b/examples/guide/model-management/src/model-manager.ts
@@ -18,6 +18,7 @@ import {
   ModelManager,
   createModelManager,
   createModelUpdaterCommandWithResult,
+  unwrapReturnResult,
 } from '@eclipse-emfcloud/model-manager';
 import { AddressBook, AddressEntry } from './address-book';
 
@@ -84,7 +85,8 @@ async function addEntryToAddressBook(modelManager: ModelManager<string>) {
 
   const addAlice = addAddressEntry(alice);
   await stack.execute(addAlice);
-  console.log('Inserted entry at index', addAlice.result!.index);
+  const result = unwrapReturnResult(addAlice);
+  console.log('Inserted entry at index', result!.index);
   console.log('Contacts address book:', inspect(addressBook));
 
   // Inserted entry at index 0

--- a/ext/model-service-theia/src/browser/__tests__/frontend-model-hub.spec.ts
+++ b/ext/model-service-theia/src/browser/__tests__/frontend-model-hub.spec.ts
@@ -152,6 +152,43 @@ describe('FrontendModelHub', () => {
       sinon.assert.calledWithMatch(onModelChanged, MODEL1_ID, MODEL1, patch);
     });
 
+    it('subscription sees consistent model', async () => {
+      const sub = await modelHub.subscribe();
+
+      let sawCorrectModelId = false;
+      let sawCorrectModelObject = false;
+
+      const gatherAssertions: (
+        modelId: string,
+        model: object
+      ) => Promise<void> = async (modelId, model) => {
+        sawCorrectModelId = modelId === MODEL1_ID;
+        const currentModel2 = await modelHub.getModel(modelId);
+        sawCorrectModelObject = currentModel2 === model;
+      };
+
+      let assertions: Promise<void> = Promise.reject(
+        new Error('onModelChange not called')
+      );
+
+      sub.onModelChanged = (modelId, model) =>
+        (assertions = gatherAssertions(modelId, model));
+
+      const patch: Operation[] = [
+        { op: 'replace', path: '/name', value: MODEL1.name },
+      ];
+      fake.fakeModelChange(MODEL1_ID, patch);
+      await asyncsResolved();
+
+      await assertions;
+      expect(sawCorrectModelId, 'incorrect model ID in subscription call-back')
+        .to.be.true;
+      expect(
+        sawCorrectModelObject,
+        'incorrect model retrieved from hub during subscription call-back'
+      ).to.be.true;
+    });
+
     it('notifies dirty state', async () => {
       const sub = await modelHub.subscribe(MODEL1_ID);
       sub.onModelDirtyState = onModelDirtyState;

--- a/ext/model-service-theia/src/browser/frontend-model-hub-subscriber.ts
+++ b/ext/model-service-theia/src/browser/frontend-model-hub-subscriber.ts
@@ -144,6 +144,7 @@ export class FrontendModelHubSubscriberImpl<K = string>
       this.trackingSubs.forEach((sub) => sub.onModelHubCreated?.(context));
     },
     onModelHubDestroyed: (context) => {
+      this.closeContext(context);
       this.knownModelHubs.delete(context);
       this.trackingSubs.forEach((sub) => sub.onModelHubDestroyed?.(context));
     },
@@ -248,14 +249,16 @@ export class FrontendModelHubSubscriberImpl<K = string>
   protected closeSub(subscriptionId: number): void {
     const context = this.getSubscriptionContext(subscriptionId);
     if (context !== undefined) {
-      this.subscriptionPipelines.delete(context);
-
-      const newSubs = this.subscriptions.filter(
-        (sub) => sub.context !== context
-      );
-      this.subscriptions.length = 0;
-      this.subscriptions.push(...newSubs);
+      this.closeContext(context);
     }
+  }
+
+  protected closeContext(context: string): void {
+    this.subscriptionPipelines.delete(context);
+
+    const newSubs = this.subscriptions.filter((sub) => sub.context !== context);
+    this.subscriptions.length = 0;
+    this.subscriptions.push(...newSubs);
   }
 
   protected updateModelCache(

--- a/ext/model-service-theia/src/common/promise-util.ts
+++ b/ext/model-service-theia/src/common/promise-util.ts
@@ -16,7 +16,7 @@
 import { CancellationError, Emitter } from '@theia/core';
 import { wait, waitForEvent } from '@theia/core/lib/common/promise-util';
 
-const DEFAULT_TIMEOUT = 30_000;
+const DEFAULT_TIMEOUT = 30_000 * 4;
 
 const stateProp = Symbol('state');
 

--- a/npm/model-manager/src/core/__tests__/command.spec.ts
+++ b/npm/model-manager/src/core/__tests__/command.spec.ts
@@ -22,10 +22,14 @@ import sinonChai from 'sinon-chai';
 import type { Command, CompoundCommand, SimpleCommand } from '../command';
 import {
   append,
+  CommandReturnResult,
   CompoundCommandImpl,
+  FailedResult,
   groupByModelId,
   isCompoundCommand,
   isSimpleCommandWithResult,
+  ReadyResult,
+  unwrapReturnResult,
 } from '../command';
 
 chai.use(chaiLike);
@@ -117,11 +121,50 @@ describe('Command-related functions', () => {
     });
 
     it('is', () => {
-      const command = new TestCommand('test', 'model1');
-      Object.assign(command, { result: 'ok' });
+      const command = new TestCommandWithResult('test', 'model1');
       const isIt = isSimpleCommandWithResult(command);
 
       expect(isIt).to.be.true;
+    });
+  });
+
+  describe('unwrapReturnResult', () => {
+    it('pending', () => {
+      const command = new TestCommandWithResult('test', 'model1');
+      const unwrapped = unwrapReturnResult(command);
+
+      expect(unwrapped).to.be.undefined;
+    });
+
+    it('failed', () => {
+      const command = Object.assign(new TestCommand('test', 'model1'), {
+        result: {
+          status: 'failed',
+          error: new Error('💣'),
+        } satisfies FailedResult,
+      });
+      expect(() => unwrapReturnResult(command)).to.throw('💣');
+    });
+
+    it('failed without detail', () => {
+      const command = Object.assign(new TestCommand('test', 'model1'), {
+        result: {
+          status: 'failed',
+        } satisfies FailedResult,
+      });
+      expect(() => unwrapReturnResult(command)).to.throw();
+    });
+
+    it('ready', () => {
+      const command = Object.assign(new TestCommand('test', 'model1'), {
+        result: {
+          status: 'ready',
+          value: 'Hello, world!',
+        } satisfies ReadyResult<string>,
+      });
+      const unwrapped = unwrapReturnResult(command);
+
+      expect(unwrapped).to.be.eq('Hello, world!');
     });
   });
 
@@ -878,4 +921,8 @@ class AsyncTestCommand implements SimpleCommand {
       throw new Error(`Failed on ${op} as directed.`);
     }
   }
+}
+
+class TestCommandWithResult extends TestCommand {
+  result: CommandReturnResult<unknown> = { status: 'pending' };
 }

--- a/npm/model-manager/src/core/command.ts
+++ b/npm/model-manager/src/core/command.ts
@@ -35,16 +35,56 @@ export type SimpleCommandResult = MaybePromise<Operation[] | undefined>;
  */
 export interface SimpleCommandWithResult<K, R> extends SimpleCommand<K> {
   /**
-   * The abstract result of the command, available once it has been successfully executed.
-   * The value is `undefined` until the command is executed.
+   * The abstract return-result of the command, available once it has been successfully executed.
+   * The value is {@link PendingResult pending} until the command is executed.
    *
    * Whether the `result` value remains available or valid after the command is undone or redone
    * is not specified. In general, it is recommended only to access this result after the initial
    * execution of the command.
    *
+   * The `result` property should be initialized to a {@link PendingResult} so that the command
+   * may be {@linkplain isSimpleCommandWithResult recognized as providing the result} eventually
+   * after execution.
+   *
    * @see {@link SimpleCommand.execute}
    */
-  readonly result: R | undefined;
+  readonly result: CommandReturnResult<R>;
+}
+
+/**
+ * The specific return-result of a {@link SimpleCommandWithResult} that provides
+ * an application-specific representation of the command's accomplished effect.
+ */
+export type CommandReturnResult<R> =
+  | ReadyResult<R>
+  | PendingResult
+  | FailedResult;
+
+/**
+ * Representation of a simple command result that is ready following
+ * successful execution of the command.
+ */
+export interface ReadyResult<R> {
+  status: 'ready';
+  value: R;
+}
+
+/**
+ * Representation of a simple command result that is not yet ready because
+ * execution of the command has not been completed (or perhaps not even started).
+ */
+export interface PendingResult {
+  status: 'pending';
+}
+
+/**
+ * Representation of a simple command result that is not and will not be ready because
+ * execution of the command has failed.
+ */
+export interface FailedResult {
+  status: 'failed';
+  /** An optional error message, compatible with common `Error` types. */
+  error?: { message: string };
 }
 
 /**
@@ -55,8 +95,36 @@ export const isSimpleCommandWithResult = <K, R>(
 ): command is SimpleCommandWithResult<K, R> => {
   return (
     !isCompoundCommand(command) &&
-    Object.prototype.hasOwnProperty.call(command, 'result')
+    'result' in command &&
+    !!command.result &&
+    typeof command.result === 'object' &&
+    'status' in command.result &&
+    typeof command.result.status === 'string'
   );
+};
+
+/**
+ * Unwrap the return result of a {@link SimpleCommandWithResult}.
+ *
+ * @returns the return-result `value` if it is `ready`, otherwise `undefined` if it is
+ *   still `pending`
+ * @throws the return-result `error` if it is `failed`
+ */
+export const unwrapReturnResult = <K, R>(
+  command: SimpleCommandWithResult<K, R>
+): R | undefined => {
+  const result = command.result;
+  switch (result.status) {
+    case 'ready':
+      return result.value;
+    case 'failed':
+      if (result.error) {
+        throw result.error;
+      }
+      throw new Error('Command failed.');
+    default: // 'pending'
+      return undefined;
+  }
 };
 
 /**

--- a/npm/model-manager/src/core/deferred-compound-command.ts
+++ b/npm/model-manager/src/core/deferred-compound-command.ts
@@ -1,0 +1,109 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: MIT License which is
+// available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: EPL-2.0 OR MIT
+// *****************************************************************************
+
+import { Command, CompoundCommand } from './command';
+import { MaybePromise } from './promises';
+import { DeferredCompoundCommand } from '../impl/deferred-compound-command-impl';
+
+/**
+ * The signature of a function that provides, just in time, the commands to add to
+ * to a deferred compound. This function is called only when the commands are actually
+ * need to execute them or, in the case of a _strict deferred compound_, to test them
+ * for whether they can be executed. The function may be asynchronous, and the
+ * commands that it returns may themselves be promises from asynchronous functions.
+ *
+ * A particularly convenient kind of function to supply as the provider is a
+ * generator that yields commands as it determines that they are required, until
+ * there are no further commands to provide.
+ *
+ * @param `getModel` a function that the provider may use to access the current
+ *   state of a model identified by `modelId` to determine whether and which commands
+ *   to provide
+ * @returns the commands to include in the compound when it is executed
+ */
+export type CommandProvider<K> = (
+  getModel: <M extends object>(modelId: K) => M | undefined
+) => MaybePromise<Iterable<MaybePromise<Command<K>>>>;
+
+/**
+ * Signature of the optional precondition function for deferred compound commands.
+ *
+ * @param `getModel` a function that the predicate may use to access the current
+ *   state of a model identified by `modelId`, to check conditions on it
+ * @returns whether the deferred compound command is determined to be executable
+ */
+export type PreconditionPredicate<K> = (
+  getModel: <M extends object>(modelId: K) => M | undefined
+) => MaybePromise<boolean>;
+
+/**
+ * Create a compound command that dynamically computes its child commands, just in
+ * time when executed. Because the determination of its member commands is deferred,
+ * the deferred compound requires up-front declaration of the `scope` of commands that
+ * it is intended to edit, so that it may exclude concurrent modifications of those
+ * models while its own execution is pending. The `children` eventually computed need
+ * not actually modify all models in this `scope` and they should not modify more
+ * models than are declared in the `scope`, which could result in unpredictable
+ * interference with other commands concurrently executed.
+ *
+ * While it is not anticipated to be typical usage, the resulting compound command
+ * does support the explicit addition of child commands in addition to the deferred
+ * provision of children. Any overlap or other interference between commands statically
+ * and dynamically added is the responsibility of the client.
+ *
+ * @template  <K> the model ID type
+ *
+ * @param label a label for the compound command, suitable for presentation in some UI
+ * @param scope the IDs of models that the compound command will edit
+ * @param children a function providing the children to add to the compound just in time
+ *    for them to be executed
+ * @param precondition an optional predicate function to compute, without having to create
+ *    them, whether the commands to be provided for execution will be executable.
+ *    If omitted, it is assumed that the compound overall will be able to be executed
+ */
+export function createDeferredCompoundCommand<K = string>(
+  label: string,
+  scope: K[],
+  children: CommandProvider<K>,
+  precondition?: PreconditionPredicate<K>
+): CompoundCommand<K> {
+  return new DeferredCompoundCommand(label, scope, children, precondition);
+}
+
+/**
+ * Create a compound command that dynamically computes its child commands, just in
+ * time when needing to query whether they can be executed. This is different to the
+ * {@link createDeferredCompoundCommand|more flexible deferred compound} in that the
+ * children are provided at the time of testing whether the command can be executed,
+ * delegating that precondition to the provided children in the usual manner of a
+ * compound command. Thus the children are prepared earlier but are guaranteed not
+ * to attempt their execution if any of them reports not being executable.
+ *
+ * @template  <K> the model ID type
+ *
+ * @param label a label for the compound command, suitable for presentation in some UI
+ * @param scope the IDs of models that the compound command will edit
+ * @param children a function providing the children to add to the compound just in time
+ *    for them to be tested for executability
+ *
+ * @see {@link createDeferredCompoundCommand()}
+ */
+export function createStrictDeferredCompoundCommand<K = string>(
+  label: string,
+  scope: K[],
+  children: CommandProvider<K>
+): CompoundCommand<K> {
+  return new DeferredCompoundCommand(label, scope, children, 'strict');
+}

--- a/npm/model-manager/src/core/index.ts
+++ b/npm/model-manager/src/core/index.ts
@@ -18,5 +18,6 @@ export * from './command';
 export * from './command-stack-subscription';
 export * from './core-command-stack';
 export * from './core-model-manager';
+export * from './deferred-compound-command';
 export * from './editing-context';
 export * from './promises';

--- a/npm/model-manager/src/impl/__tests__/core-command-stack-impl.spec.ts
+++ b/npm/model-manager/src/impl/__tests__/core-command-stack-impl.spec.ts
@@ -31,6 +31,7 @@ import {
   append,
   AppendableCompoundCommand,
   CoreCommandStackImpl,
+  getModelIds,
   StackEntry,
   WorkingCopyManager,
 } from '../core-command-stack-impl';
@@ -352,6 +353,8 @@ describe('CoreCommandStackImpl', () => {
   const context2 = editingContext('test.c2');
   let command1: TestCommand;
   let command2: TestCommand;
+  let command3: TestCommand;
+  let compound: AppendableCompoundCommand;
   let stack: CoreCommandStackImpl;
   let sandbox: sinon.SinonSandbox;
 
@@ -795,6 +798,11 @@ describe('CoreCommandStackImpl', () => {
     beforeEach(() => {
       command1 = new TestCommand('a');
       command2 = new TestCommand('b');
+      command3 = new TestCommand('c', 'test-model-id-3');
+      compound = new AppendableCompoundCommand(
+        'test',
+        ...[command1, command2, command3]
+      );
       stack = new CoreCommandStackImpl(workingCopyManager);
     });
 
@@ -2196,6 +2204,19 @@ describe('CoreCommandStackImpl', () => {
           'Uncaught exception in CoreCommandStack call-back.'
         );
         expect(allContextsCallback).to.have.been.called;
+      });
+    });
+
+    describe('get model Ids', () => {
+      it('should return an array with the single command model id', () => {
+        expect(getModelIds(command1)).to.be.eql(['test-model']);
+      });
+
+      it('should return an array with the compound command model ids', () => {
+        expect(getModelIds(compound)).to.be.eql([
+          'test-model',
+          'test-model-id-3',
+        ]);
       });
     });
   });

--- a/npm/model-manager/src/impl/__tests__/core-model-manager-impl.spec.ts
+++ b/npm/model-manager/src/impl/__tests__/core-model-manager-impl.spec.ts
@@ -26,7 +26,7 @@ import type {
   EditingContext,
   SimpleCommand,
 } from '../../core';
-import { append } from '../../core';
+import { append, createDeferredCompoundCommand } from '../../core';
 import { createModelUpdaterCommand } from '../../patch';
 import { WorkingCopyManager } from '../core-command-stack-impl';
 import { CoreModelManagerImpl } from '../core-model-manager-impl';
@@ -679,13 +679,31 @@ describe('CoreModelManagerImpl', () => {
         []
       );
       try {
-        workingCopyManager.commit(results);
+        workingCopyManager.commit(results, ['nonesuch']);
 
         expect(workingCopyManager.isOpen(['nonesuch'])).to.be.false;
         expect(workingCopyManager.isOpen([key1])).to.be.true;
       } finally {
         workingCopyManager.cancel([key1]);
       }
+    });
+
+    it('no-op deferred command', async () => {
+      modelManager.setModel(key1, model1);
+      modelManager.setModel(key2, model2);
+
+      // a deferred command that specifies 2 models, but only uses one.
+      const deferredCommand = createDeferredCompoundCommand(
+        'test command',
+        [key1, key2],
+        () => {
+          return [new TestCommand('test', key1)];
+        }
+      );
+
+      await commandStack.execute(deferredCommand, context1);
+      expect(workingCopyManager.isOpen([key1])).to.be.false;
+      expect(workingCopyManager.isOpen([key2])).to.be.false;
     });
 
     describe('concurrent working copy sets', () => {

--- a/npm/model-manager/src/impl/__tests__/deferred-compound-command.spec.ts
+++ b/npm/model-manager/src/impl/__tests__/deferred-compound-command.spec.ts
@@ -1,0 +1,497 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: MIT License which is
+// available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: EPL-2.0 OR MIT
+// *****************************************************************************
+
+import chai, { expect } from 'chai';
+import chaiAsPromised from 'chai-as-promised';
+import { Command, CompoundCommand, SimpleCommand } from '../../core/command';
+import {
+  createDeferredCompoundCommand,
+  createStrictDeferredCompoundCommand,
+} from '../../core/deferred-compound-command';
+import { DeferredCompoundCommand } from '../deferred-compound-command-impl';
+import {
+  AppendableCompoundCommand,
+  getModelIds,
+} from '../core-command-stack-impl';
+import type { Operation } from 'fast-json-patch';
+import chaiLike from 'chai-like';
+import sinon from 'sinon';
+import sinonChai from 'sinon-chai';
+
+chai.use(chaiLike);
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
+describe('optimistic DeferredCompoundCommand', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  let getModel: (modelId: string) => object | undefined;
+  let commands: Command[];
+  let compound: CompoundCommand;
+
+  const provideCommands = () => commands;
+  const provideCommandsAsync = async () => commands;
+  const provideAsyncCommands = function* () {
+    for (const cmd of commands) {
+      const next = (async () => cmd)();
+      yield next;
+    }
+  };
+  const provideAsyncCommandsAsync = async function () {
+    const result = [];
+    for (const cmd of provideAsyncCommands()) {
+      result.push(cmd);
+    }
+    return result;
+  };
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    getModel = () => ({});
+    commands = [new AsyncTestCommand('a'), new AsyncTestCommand('b')];
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('no commands, yet', () => {
+    compound = createDeferredCompoundCommand(
+      'sync-sync',
+      ['the-model'],
+      provideCommands
+    );
+    expect(compound.getCommands()).to.be.an.empty('array');
+  });
+
+  describe('execute', () => {
+    it('sync provider, sync commands', async () => {
+      const provider = sandbox.spy(provideCommands);
+
+      compound = createDeferredCompoundCommand(
+        'sync-sync',
+        ['the-model'],
+        provider
+      );
+
+      await compound.execute(getModel);
+
+      expect(commands, 'commands not executed').to.be.like([
+        { wasExecuted: true },
+        { wasExecuted: true },
+      ]);
+
+      expect(provider).to.have.been.calledWithExactly(getModel);
+    });
+
+    it('async provider, sync commands', async () => {
+      compound = createDeferredCompoundCommand(
+        'async-sync',
+        ['the-model'],
+        provideCommandsAsync
+      );
+
+      await compound.execute(getModel);
+
+      expect(commands, 'commands not executed').to.be.like([
+        { wasExecuted: true },
+        { wasExecuted: true },
+      ]);
+    });
+
+    it('sync provider, async commands', async () => {
+      compound = createDeferredCompoundCommand(
+        'sync-async',
+        ['the-model'],
+        provideAsyncCommands
+      );
+
+      await compound.execute(getModel);
+
+      expect(commands, 'commands not executed').to.be.like([
+        { wasExecuted: true },
+        { wasExecuted: true },
+      ]);
+    });
+
+    it('async provider, async commands', async () => {
+      compound = createDeferredCompoundCommand(
+        'async-async',
+        ['the-model'],
+        provideAsyncCommandsAsync
+      );
+
+      await compound.execute(getModel);
+
+      expect(commands, 'commands not executed').to.be.like([
+        { wasExecuted: true },
+        { wasExecuted: true },
+      ]);
+    });
+  });
+
+  describe('canExecute', () => {
+    beforeEach(() => {
+      compound = createDeferredCompoundCommand(
+        'sync-sync',
+        ['the-model'],
+        provideCommands
+      );
+    });
+
+    it('is true', () => {
+      return expect(compound.canExecute(getModel), 'compound not executable').to
+        .eventually.be.true;
+    });
+
+    it('is false by reason of itself', async () => {
+      await compound.execute(getModel); // Make it non-executable by executing it
+
+      return expect(compound.canExecute(getModel), 'compound is executable').to
+        .eventually.be.false;
+    });
+
+    it('uses supplied predicate', async () => {
+      const predicate = sandbox.stub().returns(false);
+      compound = createDeferredCompoundCommand(
+        'sync-sync',
+        ['the-model'],
+        provideCommands,
+        predicate
+      );
+
+      await expect(compound.canExecute(getModel), 'compound is executable').to
+        .eventually.be.false;
+
+      expect(predicate).to.have.been.calledWithExactly(getModel);
+    });
+  });
+
+  describe('model scope', () => {
+    beforeEach(() => {
+      compound = createDeferredCompoundCommand(
+        'sync-sync',
+        ['the-model'],
+        provideCommands
+      );
+    });
+
+    it('reports planned scope', () => {
+      expect(getModelIds(compound)).to.be.deep.equal(['the-model']);
+    });
+
+    it('includes statically added commands', () => {
+      compound.append(new TestCommand('static', 'other-model'));
+
+      expect(getModelIds(compound)).to.be.deep.equal([
+        'the-model',
+        'other-model',
+      ]);
+    });
+
+    it('warns on scope expansion', async () => {
+      const console_warn = sandbox.stub(console, 'warn');
+      sandbox.replace(commands[1] as SimpleCommand, 'modelId', 'other-model');
+
+      expect(getModelIds(compound)).to.be.deep.equal(['the-model']);
+
+      await compound.execute(getModel);
+
+      expect(console_warn).to.have.been.calledWithMatch(
+        /.*expands the model scope.*/
+      );
+    });
+
+    it('is frozen after execution', async () => {
+      await compound.execute(getModel);
+
+      expect(() =>
+        compound.append(new TestCommand('static', 'other-model'))
+      ).to.throw('Cannot append to executed compound');
+    });
+  });
+
+  describe('corner cases', () => {
+    it('validation rejects provided commands', async () => {
+      compound = new (class extends DeferredCompoundCommand {
+        protected validate(
+          command: Command<string>
+        ): Command<string> | undefined {
+          if (command.label === 'b') {
+            return undefined;
+          }
+          return super.validate(command);
+        }
+      })('sync-sync', ['the-model'], provideCommands);
+
+      await compound.execute(getModel);
+
+      expect(commands, 'rejected commands was executed').to.be.like([
+        { wasExecuted: true },
+        { wasExecuted: false },
+      ]);
+
+      const children = compound.getCommands();
+      expect(children.length).to.be.equal(1);
+      expect(children[0]).to.be.equal(commands[0]);
+    });
+  });
+
+  describe('get model Ids with deferred command', () => {
+    it('should return an array with the compound command model ids with deferred command', () => {
+      const provider = sandbox.spy(provideCommands);
+
+      const deferredCommand = createDeferredCompoundCommand(
+        'random-deferred-command',
+        ['test-model-id-4', 'test-model-id-5'],
+        provider
+      );
+      commands = [
+        new AsyncTestCommand('a', 'test-model'),
+        new AsyncTestCommand('b', 'test-model'),
+      ];
+      compound = new AppendableCompoundCommand('test', ...commands);
+      compound.append(deferredCommand);
+      expect(getModelIds(compound)).to.be.eql([
+        'test-model',
+        'test-model-id-4',
+        'test-model-id-5',
+      ]);
+    });
+  });
+});
+
+describe('strict DeferredCompoundCommand', () => {
+  let sandbox: sinon.SinonSandbox;
+
+  let getModel: (modelId: string) => object | undefined;
+  let commands: Command[];
+  let compound: CompoundCommand;
+
+  const provideCommands = () => commands;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    getModel = () => ({});
+    commands = [new AsyncTestCommand('a'), new AsyncTestCommand('b')];
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it('no commands, yet', () => {
+    compound = createStrictDeferredCompoundCommand(
+      'sync-sync',
+      ['the-model'],
+      provideCommands
+    );
+    expect(compound.getCommands()).to.be.an.empty('array');
+  });
+
+  it('execute', async () => {
+    compound = createStrictDeferredCompoundCommand(
+      'sync-sync',
+      ['the-model'],
+      provideCommands
+    );
+
+    await compound.execute(getModel);
+
+    expect(commands, 'commands not executed').to.be.like([
+      { wasExecuted: true },
+      { wasExecuted: true },
+    ]);
+  });
+
+  describe('canExecute', () => {
+    beforeEach(() => {
+      compound = createStrictDeferredCompoundCommand(
+        'sync-sync',
+        ['the-model'],
+        provideCommands
+      );
+    });
+
+    it('is true', () => {
+      return expect(compound.canExecute(getModel), 'compound not executable').to
+        .eventually.be.true;
+    });
+
+    it('is false by reason of itself', async () => {
+      await compound.execute(getModel); // Make it non-executable by executing it
+
+      return expect(compound.canExecute(getModel), 'compound is executable').to
+        .eventually.be.false;
+    });
+
+    it('is false by reason of some provided command', async () => {
+      await commands[1].execute(getModel); // Make one non-executable by executing it
+
+      return expect(compound.canExecute(getModel), 'compound is executable').to
+        .eventually.be.false;
+    });
+
+    it('not executable if no commands provided', () => {
+      compound = createStrictDeferredCompoundCommand(
+        'sync-sync',
+        ['the-model'],
+        () => []
+      );
+
+      return expect(compound.canExecute(getModel), 'compound is executable').to
+        .eventually.be.false;
+    });
+  });
+
+  it('prepares only once', async () => {
+    const provider = sandbox.spy(provideCommands);
+    compound = createStrictDeferredCompoundCommand(
+      'sync-sync',
+      ['the-model'],
+      provider
+    );
+
+    await compound.canExecute(getModel);
+
+    expect(provider).to.have.been.calledOnce;
+
+    await compound.execute(getModel);
+
+    expect(provider).to.have.been.calledOnce;
+  });
+});
+
+//
+// Test fixtures
+//
+
+class TestCommand implements SimpleCommand {
+  constructor(public readonly label: string, public readonly modelId = '') {}
+
+  public wasExecuted = false;
+  public wasUndone = false;
+  public wasRedone = false;
+
+  canExecute(): boolean {
+    return !this.wasExecuted && !this.wasUndone && !this.wasRedone;
+  }
+
+  canUndo(): boolean {
+    return this.wasExecuted || this.wasRedone;
+  }
+
+  canRedo(): boolean {
+    return this.wasUndone;
+  }
+
+  execute(): Operation[] | undefined {
+    if (!this.canExecute()) throw new Error('cannot execute');
+    this.wasExecuted = true;
+    this.wasUndone = false;
+    this.wasRedone = false;
+    return [{ op: 'add', path: this.label, value: 'test-value' }];
+  }
+
+  undo(): Operation[] | undefined {
+    if (!this.canUndo()) throw new Error('cannot undo');
+    this.wasExecuted = false;
+    this.wasUndone = true;
+    this.wasRedone = false;
+    return [{ op: 'remove', path: this.label }];
+  }
+
+  redo(): Operation[] | undefined {
+    if (!this.canRedo()) throw new Error('cannot redo');
+    this.wasExecuted = false;
+    this.wasUndone = false;
+    this.wasRedone = true;
+    return [{ op: 'add', path: this.label, value: 'test-value' }];
+  }
+}
+
+class AsyncTestCommand implements SimpleCommand {
+  constructor(
+    public readonly label: string,
+    public readonly modelId = 'the-model'
+  ) {}
+
+  public wasExecuted = false;
+  public wasUndone = false;
+  public wasRedone = false;
+
+  private failOnOp?: keyof SimpleCommand;
+  public failed = false;
+
+  failOn(op: keyof SimpleCommand): void {
+    this.failOnOp = op;
+  }
+
+  async canExecute(): Promise<boolean> {
+    this.maybeFailOn('canExecute');
+    return !this.wasExecuted && !this.wasUndone && !this.wasRedone;
+  }
+
+  async canUndo(): Promise<boolean> {
+    this.maybeFailOn('canUndo');
+    return this.wasExecuted || this.wasRedone;
+  }
+
+  async canRedo(): Promise<boolean> {
+    this.maybeFailOn('canRedo');
+    return this.wasUndone;
+  }
+
+  async execute(): Promise<Operation[] | undefined> {
+    if (!this.canExecute()) throw new Error('cannot execute');
+    this.maybeFailOn('execute');
+
+    this.wasExecuted = true;
+    this.wasUndone = false;
+    this.wasRedone = false;
+
+    return [{ op: 'add', path: this.label, value: 'test-value' }];
+  }
+
+  async undo(): Promise<Operation[] | undefined> {
+    if (!this.canUndo()) throw new Error('cannot undo');
+    this.maybeFailOn('undo');
+
+    this.wasExecuted = false;
+    this.wasUndone = true;
+    this.wasRedone = false;
+
+    return [{ op: 'remove', path: this.label }];
+  }
+
+  async redo(): Promise<Operation[] | undefined> {
+    if (!this.canRedo()) throw new Error('cannot redo');
+    this.maybeFailOn('redo');
+
+    this.wasExecuted = false;
+    this.wasUndone = false;
+    this.wasRedone = true;
+
+    return [{ op: 'add', path: this.label, value: 'test-value' }];
+  }
+
+  private maybeFailOn(op: keyof SimpleCommand): void {
+    if (this.failOnOp === op) {
+      this.failed = true;
+      this.failOnOp = undefined;
+      throw new Error(`Failed on ${op} as directed.`);
+    }
+  }
+}

--- a/npm/model-manager/src/impl/core-command-stack-impl.ts
+++ b/npm/model-manager/src/impl/core-command-stack-impl.ts
@@ -32,6 +32,7 @@ import {
   UndoRedoOp,
   isCompoundCommand,
 } from '../core';
+import { DeferredCompoundCommand } from './deferred-compound-command-impl';
 
 import { ExclusiveExecutor } from '../util';
 
@@ -103,8 +104,11 @@ export interface WorkingCopyManager<K = string> {
   /**
    * Commit the current working copy state back to the model storage,
    * with a summary of the changes that are being committed.
+   *
+   * @param result a map of commands to the operations that were executed
+   * @param modelIds the model IDs that were opened
    */
-  commit(result: Map<Command<K>, Operation[]>): void;
+  commit(result: Map<Command<K>, Operation[]>, modelIds: K[]): void;
 
   /**
    * Discard the current working copy state and close.
@@ -419,7 +423,7 @@ export class CoreCommandStackImpl<K = string> implements CoreCommandStack<K> {
     } finally {
       try {
         if (result) {
-          workingCopyManager.commit(result);
+          workingCopyManager.commit(result, modelIds);
           this.postCommitOperations.forEach((op) => op());
         } else {
           workingCopyManager.cancel(modelIds);
@@ -1581,7 +1585,20 @@ const can = <Op extends UndoRedoOp>(op: Op): Can<Op> => {
 
 export function getModelIds<K>(command: Command<K>): K[] {
   if (isCompoundCommand(command)) {
-    return Array.from(new Set(command.map((leaf) => leaf.modelId)));
+    if (command instanceof DeferredCompoundCommand) {
+      // A deferred compound command knows its own scope
+      return command.modelScope;
+    }
+
+    const modelIdSet = new Set<K>();
+
+    // Each command may be a CompoundCommand or DeferredCompoundCommand
+    // so we need to recurse into each leaf command
+    for (const leaf of command.getCommands()) {
+      getModelIds<K>(leaf).forEach((modelId) => modelIdSet.add(modelId));
+    }
+
+    return Array.from(modelIdSet);
   } else {
     return [command.modelId];
   }

--- a/npm/model-manager/src/impl/core-model-manager-impl.ts
+++ b/npm/model-manager/src/impl/core-model-manager-impl.ts
@@ -25,7 +25,6 @@ import {
 import {
   CoreCommandStackImpl,
   WorkingCopyManager,
-  getModelIds,
 } from './core-command-stack-impl';
 
 export class CoreModelManagerImpl<K> implements CoreModelManager<K> {
@@ -236,13 +235,7 @@ class ModelStore<K = string> implements WorkingCopyManager<K> {
     return result;
   }
 
-  commit(result: Map<Command<K>, Operation[]>): void {
-    const modelIds = Array.from(result.keys()).reduce((acc, c) => {
-      const modelIds = getModelIds(c);
-      modelIds.forEach((id) => acc.add(id));
-      return acc;
-    }, new Set<K>());
-
+  commit(result: Map<Command<K>, Operation[]>, modelIds: K[]): void {
     try {
       for (const modelId of modelIds) {
         const workingCopy = this._workingCopies.get(modelId);
@@ -253,7 +246,7 @@ class ModelStore<K = string> implements WorkingCopyManager<K> {
       }
       this.notify(result);
     } finally {
-      for (const k of modelIds.keys()) {
+      for (const k of modelIds) {
         this._open.delete(k);
       }
     }

--- a/npm/model-manager/src/impl/deferred-compound-command-impl.ts
+++ b/npm/model-manager/src/impl/deferred-compound-command-impl.ts
@@ -1,0 +1,146 @@
+// *****************************************************************************
+// Copyright (C) 2024 STMicroelectronics.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License v. 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0.
+//
+// This Source Code may also be made available under the following Secondary
+// Licenses when the conditions for such availability set forth in the Eclipse
+// Public License v. 2.0 are satisfied: MIT License which is
+// available at https://opensource.org/licenses/MIT.
+//
+// SPDX-License-Identifier: EPL-2.0 OR MIT
+// *****************************************************************************
+
+import { Command, CommandResult, CompoundCommandImpl } from '../core/command';
+import {
+  CommandProvider,
+  PreconditionPredicate,
+} from '../core/deferred-compound-command';
+import { getModelIds } from './core-command-stack-impl';
+type GetModel<K> = Parameters<CommandProvider<K>>[0];
+
+/**
+ * Implementation of a compound command that permits deferred computation of its child
+ * commands with up-front declaration of the scope of models that it will edit.
+ */
+export class DeferredCompoundCommand<
+  K = string
+> extends CompoundCommandImpl<K> {
+  /**
+   * The model IDs describing the scope of models that I will edit.
+   */
+  private readonly _modelScope: K[];
+
+  /**
+   * Whether I have prepared my child commands. This is tracked as a separate state
+   * from my child commands because it cannot be inferred from them: my command
+   * provider may provide no commands and moreover commands may be statically added
+   * to me in the usual manner.
+   */
+  private _prepared = false;
+
+  /**
+   * Initializes me with my scope and a function that prepares my child commands.
+   *
+   * @label my label, for presentation in the UI
+   * @param scope the scope of models that it is anticipated will be covered by the command
+   *   when it is {@link prepare}d. This can be wider than what is eventually
+   *   required but should not be narrower.
+   * @param commandProvider a function that provides an iterable over the commands to add and
+   *   execute when it comes time to execute
+   * @param precondition an optional precondition mode to check the {@link canExecute} condition.
+   *   This may be the constant `'strict'` to prepare my child commands and check them, or a
+   *   predicate function to check without first having to prepare my commands. If omitted,
+   *   precondition check is optimistically sidelined, just returning `true`
+   */
+  constructor(
+    label: string,
+    modelScope: K[],
+    private readonly commandProvider: CommandProvider<K>,
+    private readonly precondition?: 'strict' | PreconditionPredicate<K>
+  ) {
+    super(label);
+    this._modelScope = [...modelScope];
+  }
+
+  override async canExecute(getModel: GetModel<K>): Promise<boolean> {
+    if (this.isReady() && !this.isPrepared()) {
+      if (this.precondition === undefined) {
+        return true;
+      }
+
+      if (this.precondition === 'strict') {
+        await this.prepare(getModel);
+        return super.canExecute(getModel);
+      }
+
+      return this.precondition(getModel);
+    }
+
+    // If we've already been executed, then the standard rule applies
+    return super.canExecute(getModel);
+  }
+
+  async execute(getModel: GetModel<K>): CommandResult<K> {
+    await this.prepare(getModel);
+    return super.execute(getModel);
+  }
+
+  //
+  // Deferred Compound protocol
+  //
+
+  /**
+   * Query the scope of models edited by this command, including the set declared up-front
+   * and declared by any commands already added, either statically or by the deferred provider.
+   */
+  get modelScope(): K[] {
+    const result = new Set<K>(this._modelScope);
+    this._commands
+      .flatMap((next) => getModelIds(next))
+      .forEach((modelId) => result.add(modelId));
+    return Array.from(result);
+  }
+
+  /**
+   * Query whether I have prepared my member commands from my deferred provider.
+   */
+  isPrepared(): boolean {
+    return this._prepared;
+  }
+
+  /**
+   * Prepare myself for execution by obtaining and appending the late-provided commands.
+   *
+   * @param getModel the model accessor to pass to my command provider
+   */
+  protected async prepare(getModel: GetModel<K>): Promise<void> {
+    if (this.isPrepared()) {
+      // Only prepare once
+      return;
+    }
+
+    const childrenToAdd = await this.commandProvider(getModel);
+    this._prepared = true;
+
+    for (const next of childrenToAdd) {
+      const childToAdd = this.validate(await next);
+      if (childToAdd) {
+        this.append(childToAdd);
+      }
+    }
+  }
+
+  protected validate(command: Command<K>): Command<K> | undefined {
+    const modelIds = getModelIds(command);
+    if (modelIds.some((modelId) => !this._modelScope.includes(modelId))) {
+      // For now, this is just a warning, not a validation failure
+      console.warn(
+        `Command '${command.label}' expands the model scope of deferred compound '${this.label}'.`
+      );
+    }
+    return command;
+  }
+}

--- a/npm/model-manager/src/patch/__tests__/patch-command.spec.ts
+++ b/npm/model-manager/src/patch/__tests__/patch-command.spec.ts
@@ -866,41 +866,115 @@ describe('PatchCommand', () => {
       });
     });
 
-    it('With Result', async () => {
-      type Result = {
-        ok: boolean;
-        message: string;
-      };
+    describe('With Result', () => {
+      it('success', async () => {
+        type Result = {
+          message: string;
+        };
 
-      const updaterWithResult: ModelUpdater<
-        string,
-        typeof testDocument,
-        Result
-      > = (workingCopy, modelId) => {
-        expect(modelId).to.be.equal('document');
-        workingCopy.id = 'updated-test-id';
+        const updaterWithResult: ModelUpdater<
+          string,
+          typeof testDocument,
+          Result
+        > = (workingCopy, modelId) => {
+          expect(modelId).to.be.equal('document');
+          workingCopy.id = 'updated-test-id';
 
-        return { ok: true, message: 'Hello, world.' };
-      };
+          return { message: 'Hello, world.' };
+        };
 
-      const document = cloneDeep(testDocument);
-      const expectedDocument = cloneDeep(testDocument);
-      expectedDocument.id = 'updated-test-id';
+        const document = cloneDeep(testDocument);
+        const expectedDocument = cloneDeep(testDocument);
+        expectedDocument.id = 'updated-test-id';
 
-      const command = createModelUpdaterCommandWithResult(
-        'Test Command',
-        'document',
-        updaterWithResult
-      );
+        const command = createModelUpdaterCommandWithResult(
+          'Test Command',
+          'document',
+          updaterWithResult
+        );
 
-      expect(command.result).not.to.exist;
+        expect(command.result).to.be.like({ status: 'pending' });
 
-      // Execute
-      await expect(command.canExecute(document)).to.eventually.be.true;
-      await command.execute(document);
+        // Execute
+        await expect(command.canExecute(document)).to.eventually.be.true;
+        await command.execute(document);
 
-      expect(command.result).to.exist;
-      expect(command.result).to.be.like({ ok: true, message: 'Hello, world.' });
+        expect(command.result).to.exist;
+        expect(command.result).to.be.like({
+          status: 'ready',
+          value: { message: 'Hello, world.' },
+        });
+      });
+
+      it('fails with Error', async () => {
+        const updaterWithResult: ModelUpdater<
+          string,
+          typeof testDocument,
+          unknown
+        > = () => {
+          throw new Error('💣');
+        };
+
+        const document = cloneDeep(testDocument);
+        const expectedDocument = cloneDeep(testDocument);
+        expectedDocument.id = 'updated-test-id';
+
+        const command = createModelUpdaterCommandWithResult(
+          'Test Command',
+          'document',
+          updaterWithResult
+        );
+
+        let error: Error | undefined;
+
+        await expect(command.canExecute(document)).to.eventually.be.true;
+        try {
+          await command.execute(document);
+        } catch (e) {
+          error = e;
+        }
+
+        expect(command.result).to.exist;
+        expect(command.result).to.be.like({
+          status: 'failed',
+          error,
+        });
+      });
+
+      it('fails with string', async () => {
+        const updaterWithResult: ModelUpdater<
+          string,
+          typeof testDocument,
+          unknown
+        > = () => {
+          throw '💣';
+        };
+
+        const document = cloneDeep(testDocument);
+        const expectedDocument = cloneDeep(testDocument);
+        expectedDocument.id = 'updated-test-id';
+
+        const command = createModelUpdaterCommandWithResult(
+          'Test Command',
+          'document',
+          updaterWithResult
+        );
+
+        let error: string | undefined;
+
+        await expect(command.canExecute(document)).to.eventually.be.true;
+        try {
+          await command.execute(document);
+        } catch (e) {
+          error = e;
+        }
+
+        expect(command.result).to.exist;
+        expect(command.result).to.be.like({
+          status: 'failed',
+          error,
+        });
+      });
     });
   });
 

--- a/npm/model-manager/src/patch/patch-command.ts
+++ b/npm/model-manager/src/patch/patch-command.ts
@@ -15,6 +15,7 @@
 import { Operation, applyPatch, compare } from 'fast-json-patch';
 import cloneDeep from 'lodash/cloneDeep';
 import {
+  CommandReturnResult,
   CompoundCommandImpl,
   MaybePromise,
   SimpleCommand,
@@ -324,14 +325,36 @@ export const createModelUpdaterCommandWithResult = <K, M extends object, R>(
   modelUpdater: ModelUpdater<K, M, R>,
   options?: PatchCommandOptions<K>
 ): SimpleCommandWithResult<K, R> => {
-  let _result: R | undefined;
+  let returnResult: CommandReturnResult<R> = { status: 'pending' };
   const delegate: ModelUpdater<K, M> = async (workingCopy, modelId) => {
-    _result = await modelUpdater(workingCopy, modelId);
+    try {
+      returnResult = {
+        status: 'ready',
+        value: await modelUpdater(workingCopy, modelId),
+      };
+    } catch (e: unknown) {
+      // Be sure to re-throw after creating the return-result so that
+      // the calling context of the Command Stack can unwind
+      if (
+        !!e &&
+        typeof e === 'object' &&
+        'message' in e &&
+        typeof e.message === 'string'
+      ) {
+        const error = e as { message: string };
+        returnResult = { status: 'failed', error };
+        throw e;
+      } else {
+        const error = new Error(String(e));
+        returnResult = { status: 'failed', error };
+        throw error;
+      }
+    }
   };
 
   return new (class extends PatchCommand<K> {
-    get result(): R | undefined {
-      return _result;
+    get result(): CommandReturnResult<R> {
+      return returnResult;
     }
   })(label, modelId, delegate, options);
 };

--- a/npm/model-service/src/impl/__tests__/model-hub-impl.spec.ts
+++ b/npm/model-service/src/impl/__tests__/model-hub-impl.spec.ts
@@ -813,6 +813,47 @@ describe('ModelHubImpl', () => {
     sinon.assert.calledWith(onModelValidated, MODEL_B_ID, modelB);
   });
 
+  it('subscription sees consistent model (T2CMN-274)', async () => {
+    createModelHub(testContributionA, testContributionB);
+
+    const sub = modelHub.subscribe();
+
+    let sawCorrectModelId = false;
+    let sawCorrectModelObject = false;
+    let sawExpectedModelChange = false;
+
+    const gatherAssertions: (
+      modelId: string,
+      model: object
+    ) => Promise<void> = async (modelId, model) => {
+      sawCorrectModelId = modelId === MODEL_B_ID;
+      const currentModelB = await getModelB();
+      sawCorrectModelObject = currentModelB === model;
+      sawExpectedModelChange = currentModelB.value === 42;
+    };
+
+    let assertions: Promise<void> = Promise.reject(
+      new Error('onModelChange not called')
+    );
+
+    sub.onModelChanged = (modelId, model) =>
+      (assertions = gatherAssertions(modelId, model));
+
+    await editB(42);
+
+    await assertions;
+    expect(sawCorrectModelId, 'incorrect model ID in subscription call-back').to
+      .be.true;
+    expect(
+      sawCorrectModelObject,
+      'incorrect model retrieved from hub during subscription call-back'
+    ).to.be.true;
+    expect(
+      sawExpectedModelChange,
+      'model retrieved during call-back was not yet changed'
+    ).to.be.true;
+  });
+
   it('close subscriptions', async () => {
     createModelHub(testContributionA);
 


### PR DESCRIPTION
Contributed on behalf of STMicroelectronics

Co-authored-by: Christian W. Damus <cdamus.ext@eclipsesource.com>
Co-authored-by: Anthony Fusco <anthony.fusco@st.com>
Co-authored-by: Camille Letavernier <cletavernier@eclipsesource.com>
Co-authored-by: Stefan Dirix <sdirix@eclipsesource.com>
Co-authored-by: Maxime DORTEL (STM) <maxime.dortel@st.com>
Co-authored-by: Nina Doschek <ndoschek@eclipsesource.com>
Co-authored-by: Gabriel GASNOT <gabriel.gasnot@st.com>
Co-authored-by: FlorentPastorSTM <florent.pastor@st.com>

* feat: Deferred compound commands API Implement a new API for construction of late-defined compound commands, in which
- the scope of model edits is declared up-front to exclude concurrent commands that would interfere
- executability of the compound does not require the commands to be known a priori
- a separate can-execute predicate can be provided that asserts the executability of the commands without actually having to prepare them
- a strict option does allow to prepare the compound for executability test delegating to its contained commands
- document the primary use case for the deferred compound command

* fix: clear frontend subscriptions on modelhub dispose Previously, when a ModelHub was disposed in the backend, the cached frontend pipelines were not cleared. Therefore a subscription to a now no longer existing ModelHub was reused when a ModelHub with the same context was created. As a consequence new frontend subscription to the following ModelHubs were not notified. This is now fixed.